### PR TITLE
Disable verbose debug output by default

### DIFF
--- a/src/main/rpm/macros.xmvngen
+++ b/src/main/rpm/macros.xmvngen
@@ -1,6 +1,6 @@
 # Debug enable flag.
 # Setting this to non-empty value enables debugging output.
-%__xmvngen_debug 1
+%__xmvngen_debug %nil
 
 # Path to JVM library (libjvm.so).  Java 21 or newer is required.
 %__xmvngen_libjvm %{_jvmdir}/jre-25-openjdk/lib/server/libjvm.so


### PR DESCRIPTION
The XMvn generator was producing verbose output for each generator step,
even when no meaningful work was done, leading to cluttered logs—especially
in builds with many BRPs.

Additionally, the generator sometimes emits a full Java stack trace
(e.g., `java.nio.charset.MalformedInputException`) when encountering
non-UTF-8 input. While the underlying bug should be addressed separately,
disabling debug output avoids unnecessary tracebacks in the build logs.

This commit sets the `%__xmvngen_debug` macro to `%nil` to suppress
verbose debug output by default. This results in cleaner and more
concise build logs, improving readability.

Resolves: [rhbz#2375157](https://bugzilla.redhat.com/show_bug.cgi?id=2375157)