### PR TITLE
Suppress non-fatal stack traces unless debugging is enabled

### DIFF
--- a/src/main/java/org/fedoraproject/xmvn/generator/jpms/JPMSGenerator.java
+++ b/src/main/java/org/fedoraproject/xmvn/generator/jpms/JPMSGenerator.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.fedoraproject.xmvn.generator.BuildContext;
 import org.fedoraproject.xmvn.generator.Collector;
 import org.fedoraproject.xmvn.generator.Generator;
+import org.fedoraproject.xmvn.generator.logging.Logger;
 
 class JPMSGenerator implements Generator {
     private final BuildContext context;
@@ -75,7 +76,8 @@ class JPMSGenerator implements Generator {
                                 }
                             }
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            // Continue despite exception
+                            Logger.debug(e);
                         }
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/fedoraproject/xmvn/generator/jpscript/JPackageScriptGenerator.java
+++ b/src/main/java/org/fedoraproject/xmvn/generator/jpscript/JPackageScriptGenerator.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.fedoraproject.xmvn.generator.BuildContext;
 import org.fedoraproject.xmvn.generator.Collector;
 import org.fedoraproject.xmvn.generator.Generator;
+import org.fedoraproject.xmvn.generator.logging.Logger;
 
 class JPackageScriptGenerator implements Generator {
     private final BuildContext context;
@@ -55,7 +56,7 @@ class JPackageScriptGenerator implements Generator {
                 }
             } catch (MalformedInputException e) {
                 // Continue despite exception
-                e.printStackTrace();
+                Logger.debug(e);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/src/main/java/org/fedoraproject/xmvn/generator/logging/Logger.java
+++ b/src/main/java/org/fedoraproject/xmvn/generator/logging/Logger.java
@@ -71,4 +71,10 @@ public class Logger {
                 BOX_BOTTOM_LEFT + repeat(BOX_BORDER_HORIZONTAL, BOX_WIDTH - 2) + BOX_BOTTOM_RIGHT);
         flush();
     }
+
+    public static void debug(Throwable t) {
+        if (debugEnabled) {
+            t.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/org/fedoraproject/xmvn/generator/maven/MavenGenerator.java
+++ b/src/main/java/org/fedoraproject/xmvn/generator/maven/MavenGenerator.java
@@ -295,8 +295,8 @@ class MavenGenerator implements Generator {
                     try (StringWriter sw = new StringWriter();
                             PrintWriter pw = new PrintWriter(sw)) {
                         sw.append("Unable to generate POM dependencies: ");
-                        e.printStackTrace(pw);
                         Logger.debug(sw.toString());
+                        Logger.debug(e);
                     } catch (IOException e1) {
                         throw new UncheckedIOException(e1);
                     }

--- a/src/main/java/org/fedoraproject/xmvn/generator/transformer/TransformerHook.java
+++ b/src/main/java/org/fedoraproject/xmvn/generator/transformer/TransformerHook.java
@@ -64,12 +64,14 @@ class TransformerHook implements Hook {
                     try {
                         jarTransformer.transformJar(filePath);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        // Continue despite exception
+                        Logger.debug(e);
                     }
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            // Continue despite exception
+            Logger.debug(e);
         }
     }
 


### PR DESCRIPTION
Previously, non-fatal exceptions such as MalformedInputException were
printed to the build log unconditionally, even when debug output was
not enabled. This led to confusing and noisy logs during normal builds,
especially when the generator encountered benign issues like unexpected
file encodings.

This change ensures that such stack traces are only printed when
`%__xmvngen_debug` is set to a non-empty value, aligning error reporting
with the expected debug verbosity level.

As a result, build logs are cleaner by default, while still allowing
full diagnostics when debugging is explicitly requested.

Resolves: [rhbz#2375157](https://bugzilla.redhat.com/show_bug.cgi?id=2375157)